### PR TITLE
Implement e2e tests for operation-mcp

### DIFF
--- a/misc/e2e.yaml
+++ b/misc/e2e.yaml
@@ -1,0 +1,55 @@
+actions:
+  - danger_level: high
+    type: confirm
+    message: "This is a high danger operation. Proceed? (y/n): "
+  - danger_level: medium
+    type: timeout
+    message: "This is a medium danger operation. Proceeding in 5 seconds."
+    timeout: 5
+  - danger_level: low
+    type: force
+    message: "This is a low danger operation."
+
+tools:
+  - name: echo
+    command:
+      - echo
+    subtools:
+      - name: hello
+        params:
+          message:
+            description: The message to echo
+            type: string
+            required: true
+        args: ["Hello, {{.message}}!"]
+      - name: goodbye
+        params:
+          message:
+            description: The message to echo
+            type: string
+            required: true
+        args: ["Goodbye, {{.message}}!"]
+  
+  - name: sleep
+    command:
+      - sleep
+    params:
+      seconds:
+        description: The number of seconds to sleep
+        type: string
+        required: false
+    subtools:
+      - name: short
+        args: ["1"]
+        danger_level: low
+      - name: medium
+        args: ["3"]
+        danger_level: medium
+      - name: long
+        params:
+          seconds:
+            description: The number of seconds to sleep
+            type: string
+            required: true
+        args: ["{{.seconds}}"]
+        danger_level: high

--- a/misc/run_e2e_test.sh
+++ b/misc/run_e2e_test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Define colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Build the operations binary
+cd "$(dirname "$0")/.."
+go build -o build/operations cmd/operations/main.go
+OPERATIONS_BIN="$(pwd)/build/operations"
+
+echo "Starting e2e tests..."
+echo "Using operations binary: ${OPERATIONS_BIN}"
+
+# Test 1: Echo hello
+echo -e "\n${GREEN}Test 1: Echo hello command${NC}"
+${OPERATIONS_BIN} --config "$(pwd)/misc/e2e.yaml" echo hello --message "e2e test"
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✓ Test 1 passed${NC}"
+else
+    echo -e "${RED}✗ Test 1 failed${NC}"
+    exit 1
+fi
+
+# Test 2: Echo goodbye
+echo -e "\n${GREEN}Test 2: Echo goodbye command${NC}"
+${OPERATIONS_BIN} --config "$(pwd)/misc/e2e.yaml" echo goodbye --message "e2e test"
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✓ Test 2 passed${NC}"
+else
+    echo -e "${RED}✗ Test 2 failed${NC}"
+    exit 1
+fi
+
+# Test 3: Sleep short (low danger level)
+echo -e "\n${GREEN}Test 3: Sleep short command (low danger level)${NC}"
+${OPERATIONS_BIN} --config "$(pwd)/misc/e2e.yaml" sleep short --seconds 1
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✓ Test 3 passed${NC}"
+else
+    echo -e "${RED}✗ Test 3 failed${NC}"
+    exit 1
+fi
+
+# Test 4: Sleep medium (medium danger level)
+echo -e "\n${GREEN}Test 4: Sleep medium command (medium danger level)${NC}"
+${OPERATIONS_BIN} --config "$(pwd)/misc/e2e.yaml" sleep medium --seconds 3
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✓ Test 4 passed${NC}"
+else
+    echo -e "${RED}✗ Test 4 failed${NC}"
+    exit 1
+fi
+
+# Test 5: Sleep long (high danger level)
+echo -e "\n${GREEN}Test 5: Sleep long command (high danger level)${NC}"
+echo "y" | ${OPERATIONS_BIN} --config "$(pwd)/misc/e2e.yaml" sleep long --seconds 1
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✓ Test 5 passed${NC}"
+else
+    echo -e "${RED}✗ Test 5 failed${NC}"
+    exit 1
+fi
+
+echo -e "\n${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
Fixes #3

This PR implements e2e tests for the operation-mcp project by:

1. Creating a misc/e2e.yaml file with echo and sleep tools configuration
2. Creating a misc/run_e2e_test.sh script to automate testing
3. Fixing parameter passing in main.go to properly handle flags

All tests are now passing successfully.