### PR TITLE
Add CI/CD workflows

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,27 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e-test:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+          cache: true
+
+      - name: Build application
+        run: make build
+
+      - name: Run E2E tests
+        run: bash ./misc/run_e2e_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+          cache: true
+
+      - name: Run tests
+        run: make test
+
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          install-only: true
+
+      - name: Create .goreleaser.yml
+        run: |
+          cat > .goreleaser.yml << 'EOF'
+          before:
+            hooks:
+              - go mod tidy
+          builds:
+            - id: operations
+              main: ./cmd/operations/main.go
+              binary: operations
+              env:
+                - CGO_ENABLED=0
+              goos:
+                - linux
+                - darwin
+              goarch:
+                - amd64
+                - arm64
+              ldflags:
+                - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+          archives:
+            - format: tar.gz
+              name_template: >-
+                {{ .ProjectName }}_
+                {{- .Version }}_
+                {{- .Os }}_
+                {{- if eq .Arch "amd64" }}x86_64
+                {{- else if eq .Arch "arm64" }}aarch64
+                {{- else }}{{ .Arch }}{{ end }}
+              format_overrides:
+                - goos: windows
+                  format: zip
+          checksum:
+            name_template: 'checksums.txt'
+          snapshot:
+            name_template: "{{ incpatch .Version }}-next"
+          changelog:
+            sort: asc
+            filters:
+              exclude:
+                - '^docs:'
+                - '^test:'
+                - '^ci:'
+                - '^chore:'
+          EOF
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+          cache: true
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Run test with coverage
+        run: make test-coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.html


### PR DESCRIPTION
Implements #5

This PR adds CI/CD workflows as requested:

- Unit tests workflow (triggered on PR open)
- E2E tests workflow (triggered on workflow_dispatch and main push)
- Release workflow (triggered on tag push) that:
  - Creates a GitHub release
  - Uses goreleaser to build binaries for mac and linux (x86 and aarch64)