### PR TITLE
Apply go fmt to fix code formatting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,14 +59,14 @@ type Parameters map[string]Parameter
 
 // SSHConfig represents SSH connection configuration
 type SSHConfig struct {
-	Host      string  `yaml:"host,omitempty"`
-	Port      int     `yaml:"port,omitempty"`
-	User      string  `yaml:"user,omitempty"`
-	Password  string  `yaml:"password,omitempty"`
-	KeyPath   string  `yaml:"key,omitempty"`
-	VerifyHost *bool   `yaml:"verify_host,omitempty"`
+	Host        string `yaml:"host,omitempty"`
+	Port        int    `yaml:"port,omitempty"`
+	User        string `yaml:"user,omitempty"`
+	Password    string `yaml:"password,omitempty"`
+	KeyPath     string `yaml:"key,omitempty"`
+	VerifyHost  *bool  `yaml:"verify_host,omitempty"`
 	HostKeyPath string `yaml:"host_key_path,omitempty"`
-	Timeout   int     `yaml:"timeout,omitempty"` // in seconds
+	Timeout     int    `yaml:"timeout,omitempty"` // in seconds
 }
 
 // LoadConfig loads the configuration from a file


### PR DESCRIPTION
This PR applies go fmt to fix code formatting in the repository, specifically in pkg/config/config.go where struct field types are now properly aligned.