### PR TITLE
Fix golint issues: rename ToolInfo to Info

### DIFF
--- a/cmd/operations/main.go
+++ b/cmd/operations/main.go
@@ -1,364 +1,364 @@
 package main
 
 import (
-        "fmt"
-        "os"
-        "strings"
-        "time"
+	"fmt"
+	"os"
+	"strings"
+	"time"
 
-        "github.com/spf13/cobra"
-        "github.com/spf13/pflag"
-        "github.com/takutakahashi/operation-mcp/pkg/config"
-        "github.com/takutakahashi/operation-mcp/pkg/tool"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/takutakahashi/operation-mcp/pkg/config"
+	"github.com/takutakahashi/operation-mcp/pkg/tool"
 )
 
 var (
-        configPath string
-        cfg        *config.Config
-        toolMgr    *tool.Manager
+	configPath string
+	cfg        *config.Config
+	toolMgr    *tool.Manager
 
-        // SSH関連のフラグ
-        remoteMode    bool
-        sshHost       string
-        sshUser       string
-        sshKeyPath    string
-        sshPassword   string
-        sshPort       int
-        sshTimeout    time.Duration
-        sshVerifyHost bool
+	// SSH関連のフラグ
+	remoteMode    bool
+	sshHost       string
+	sshUser       string
+	sshKeyPath    string
+	sshPassword   string
+	sshPort       int
+	sshTimeout    time.Duration
+	sshVerifyHost bool
 )
 
 func main() {
-        // Parse config from flags directly to handle it early
-        for i, arg := range os.Args {
-                if strings.HasPrefix(arg, "--config=") {
-                        configPath = strings.TrimPrefix(arg, "--config=")
-                        break
-                } else if arg == "--config" && i+1 < len(os.Args) {
-                        configPath = os.Args[i+1]
-                        break
-                }
-        }
+	// Parse config from flags directly to handle it early
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, "--config=") {
+			configPath = strings.TrimPrefix(arg, "--config=")
+			break
+		} else if arg == "--config" && i+1 < len(os.Args) {
+			configPath = os.Args[i+1]
+			break
+		}
+	}
 
-        // Try to load the config early
-        var err error
-        if configPath != "" {
-                cfg, err = config.LoadConfig(configPath)
-                if err != nil {
-                        fmt.Printf("Warning: Failed to load config from %s: %v\n", configPath, err)
-                }
-        }
+	// Try to load the config early
+	var err error
+	if configPath != "" {
+		cfg, err = config.LoadConfig(configPath)
+		if err != nil {
+			fmt.Printf("Warning: Failed to load config from %s: %v\n", configPath, err)
+		}
+	}
 
-        rootCmd := &cobra.Command{
-                Use:   "operations",
-                Short: "Operations CLI tool",
-                Long:  "A CLI tool for executing operations defined in a configuration file",
-                PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-                        // If we already loaded the config, we can skip this
-                        if cfg != nil {
-                                return nil
-                        }
+	rootCmd := &cobra.Command{
+		Use:   "operations",
+		Short: "Operations CLI tool",
+		Long:  "A CLI tool for executing operations defined in a configuration file",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// If we already loaded the config, we can skip this
+			if cfg != nil {
+				return nil
+			}
 
-                        var err error
-                        cfg, err = config.LoadConfig(configPath)
-                        if err != nil {
-                                return fmt.Errorf("failed to load config: %w", err)
-                        }
+			var err error
+			cfg, err = config.LoadConfig(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
 
-                        if err := cfg.Validate(); err != nil {
-                                return fmt.Errorf("invalid configuration: %w", err)
-                        }
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("invalid configuration: %w", err)
+			}
 
-                        // Create and configure the tool manager
-                        toolMgr = tool.NewManager(cfg)
+			// Create and configure the tool manager
+			toolMgr = tool.NewManager(cfg)
 
-                        // Create the appropriate executor based on flags
-                        exec, err := createExecutor()
-                        if err != nil {
-                                return fmt.Errorf("failed to create executor: %w", err)
-                        }
+			// Create the appropriate executor based on flags
+			exec, err := createExecutor()
+			if err != nil {
+				return fmt.Errorf("failed to create executor: %w", err)
+			}
 
-                        // Set executor for the tool manager
-                        toolMgr.WithExecutor(exec)
+			// Set executor for the tool manager
+			toolMgr.WithExecutor(exec)
 
-                        return nil
-                },
-        }
+			return nil
+		},
+	}
 
-        rootCmd.PersistentFlags().StringVar(&configPath, "config", configPath, "path to config file")
+	rootCmd.PersistentFlags().StringVar(&configPath, "config", configPath, "path to config file")
 
-        // SSH関連のフラグを追加
-        rootCmd.PersistentFlags().BoolVar(&remoteMode, "remote", false, "Enable remote execution mode via SSH")
-        rootCmd.PersistentFlags().StringVar(&sshHost, "host", "", "SSH remote host")
-        rootCmd.PersistentFlags().StringVar(&sshUser, "user", "", "SSH username")
-        rootCmd.PersistentFlags().StringVar(&sshKeyPath, "key", "", "Path to SSH private key")
-        rootCmd.PersistentFlags().StringVar(&sshPassword, "password", "", "SSH password (not recommended)")
-        rootCmd.PersistentFlags().IntVar(&sshPort, "port", 22, "SSH port")
-        rootCmd.PersistentFlags().DurationVar(&sshTimeout, "timeout", 10*time.Second, "SSH connection timeout")
-        rootCmd.PersistentFlags().BoolVar(&sshVerifyHost, "verify-host", true, "Verify host key")
+	// SSH関連のフラグを追加
+	rootCmd.PersistentFlags().BoolVar(&remoteMode, "remote", false, "Enable remote execution mode via SSH")
+	rootCmd.PersistentFlags().StringVar(&sshHost, "host", "", "SSH remote host")
+	rootCmd.PersistentFlags().StringVar(&sshUser, "user", "", "SSH username")
+	rootCmd.PersistentFlags().StringVar(&sshKeyPath, "key", "", "Path to SSH private key")
+	rootCmd.PersistentFlags().StringVar(&sshPassword, "password", "", "SSH password (not recommended)")
+	rootCmd.PersistentFlags().IntVar(&sshPort, "port", 22, "SSH port")
+	rootCmd.PersistentFlags().DurationVar(&sshTimeout, "timeout", 10*time.Second, "SSH connection timeout")
+	rootCmd.PersistentFlags().BoolVar(&sshVerifyHost, "verify-host", true, "Verify host key")
 
-        // Add the exec command
-        execCmd := &cobra.Command{
-                Use:   "exec [tool_subtool] [args...]",
-                Short: "Execute a specific subtool with parameters",
-                Long:  `Execute a tool's subtool with parameters. The tool_subtool must be specified in the format "tool_subtool", e.g. "kubectl_get_pod".`,
-                Args:  cobra.MinimumNArgs(1),
-                Run: func(cmd *cobra.Command, args []string) {
-                        toolPath := args[0]
-                        toolArgs := []string{}
-                        if len(args) > 1 {
-                                toolArgs = args[1:]
-                        }
+	// Add the exec command
+	execCmd := &cobra.Command{
+		Use:   "exec [tool_subtool] [args...]",
+		Short: "Execute a specific subtool with parameters",
+		Long:  `Execute a tool's subtool with parameters. The tool_subtool must be specified in the format "tool_subtool", e.g. "kubectl_get_pod".`,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			toolPath := args[0]
+			toolArgs := []string{}
+			if len(args) > 1 {
+				toolArgs = args[1:]
+			}
 
-                        if err := toolMgr.ExecuteRawTool(toolPath, toolArgs); err != nil {
-                                fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-                                os.Exit(1)
-                        }
-                },
-        }
+			if err := toolMgr.ExecuteRawTool(toolPath, toolArgs); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
 
-        rootCmd.AddCommand(execCmd)
+	rootCmd.AddCommand(execCmd)
 
-        // Add the list command
-        listCmd := &cobra.Command{
-                Use:   "list",
-                Short: "List all available tools",
-                Long:  `List all available tools and their subtools defined in the configuration file`,
-                Run: func(cmd *cobra.Command, args []string) {
-                        // If toolMgr is nil, we couldn't load a config
-                        if toolMgr == nil {
-                                fmt.Println("No tools available. Please provide a valid configuration file.")
-                                return
-                        }
+	// Add the list command
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all available tools",
+		Long:  `List all available tools and their subtools defined in the configuration file`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// If toolMgr is nil, we couldn't load a config
+			if toolMgr == nil {
+				fmt.Println("No tools available. Please provide a valid configuration file.")
+				return
+			}
 
-                        // Get verbose flag
-                        verbose, _ := cmd.Flags().GetBool("verbose")
+			// Get verbose flag
+			verbose, _ := cmd.Flags().GetBool("verbose")
 
-                        // Get tools list
-                        tools := toolMgr.ListTools()
+			// Get tools list
+			tools := toolMgr.ListTools()
 
-                        // Display header
-                        fmt.Println("Available tools:")
-                        fmt.Println()
+			// Display header
+			fmt.Println("Available tools:")
+			fmt.Println()
 
-                        // Display tools
-                        for _, tool := range tools {
-                                fmt.Println(tool.Name)
+			// Display tools
+			for _, tool := range tools {
+				fmt.Println(tool.Name)
 
-                                // Display subtools recursively
-                                printSubtools(tool.Subtools, 1, tool.Name, verbose)
+				// Display subtools recursively
+				printSubtools(tool.Subtools, 1, tool.Name, verbose)
 
-                                fmt.Println() // Empty line between tools
-                        }
-                },
-        }
+				fmt.Println() // Empty line between tools
+			}
+		},
+	}
 
-        // Add verbose flag
-        listCmd.Flags().BoolP("verbose", "v", false, "Show detailed information including parameters")
+	// Add verbose flag
+	listCmd.Flags().BoolP("verbose", "v", false, "Show detailed information including parameters")
 
-        rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(listCmd)
 
-        // If we have a config, add commands for each tool
-        if cfg != nil {
-                // Create and configure the tool manager
-                toolMgr = tool.NewManager(cfg)
+	// If we have a config, add commands for each tool
+	if cfg != nil {
+		// Create and configure the tool manager
+		toolMgr = tool.NewManager(cfg)
 
-                // Create the appropriate executor based on flags
-                exec, err := createExecutor()
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Warning: Failed to create executor: %v\n", err)
-                } else {
-                        // Set executor for the tool manager
-                        toolMgr.WithExecutor(exec)
-                }
+		// Create the appropriate executor based on flags
+		exec, err := createExecutor()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to create executor: %v\n", err)
+		} else {
+			// Set executor for the tool manager
+			toolMgr.WithExecutor(exec)
+		}
 
-                for _, tool := range cfg.Tools {
-                        toolCmd := createToolCommand(tool)
-                        rootCmd.AddCommand(toolCmd)
-                }
-        }
+		for _, tool := range cfg.Tools {
+			toolCmd := createToolCommand(tool)
+			rootCmd.AddCommand(toolCmd)
+		}
+	}
 
-        if err := rootCmd.Execute(); err != nil {
-                fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-                os.Exit(1)
-        }
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func createToolCommand(tool config.Tool) *cobra.Command {
-        toolCmd := &cobra.Command{
-                Use:   tool.Name,
-                Short: fmt.Sprintf("Execute %s command", tool.Name),
-                Run: func(cmd *cobra.Command, args []string) {
-                        // If no subtools, execute the tool directly
-                        if len(tool.Subtools) == 0 {
-                                paramValues := getParamValues(cmd, tool.Params)
-                                if err := toolMgr.ExecuteTool(tool.Name, paramValues); err != nil {
-                                        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-                                        os.Exit(1)
-                                }
-                                return
-                        }
+	toolCmd := &cobra.Command{
+		Use:   tool.Name,
+		Short: fmt.Sprintf("Execute %s command", tool.Name),
+		Run: func(cmd *cobra.Command, args []string) {
+			// If no subtools, execute the tool directly
+			if len(tool.Subtools) == 0 {
+				paramValues := getParamValues(cmd, tool.Params)
+				if err := toolMgr.ExecuteTool(tool.Name, paramValues); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
 
-                        // Otherwise, show help
-                        cmd.Help()
-                },
-        }
+			// Otherwise, show help
+			cmd.Help()
+		},
+	}
 
-        // Add flags for tool parameters
-        addParamFlags(toolCmd, tool.Params)
+	// Add flags for tool parameters
+	addParamFlags(toolCmd, tool.Params)
 
-        // Add subcommands for each subtool
-        for _, subtool := range tool.Subtools {
-                subtoolCmd := createSubtoolCommand(tool.Name, subtool)
+	// Add subcommands for each subtool
+	for _, subtool := range tool.Subtools {
+		subtoolCmd := createSubtoolCommand(tool.Name, subtool)
 
-                // Add parent tool's parameters to subtool command
-                for name, param := range tool.Params {
-                        // Skip adding the flag if it already exists
-                        exists := false
-                        subtoolCmd.Flags().VisitAll(func(flag *pflag.Flag) {
-                                if flag.Name == name {
-                                        exists = true
-                                }
-                        })
-                        if exists {
-                                continue
-                        }
+		// Add parent tool's parameters to subtool command
+		for name, param := range tool.Params {
+			// Skip adding the flag if it already exists
+			exists := false
+			subtoolCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+				if flag.Name == name {
+					exists = true
+				}
+			})
+			if exists {
+				continue
+			}
 
-                        switch param.Type {
-                        case "string":
-                                subtoolCmd.Flags().String(name, "", param.Description)
-                        case "int", "number":
-                                subtoolCmd.Flags().Int(name, 0, param.Description)
-                        case "bool", "boolean":
-                                subtoolCmd.Flags().Bool(name, false, param.Description)
-                        default:
-                                // Default to string for unknown types
-                                subtoolCmd.Flags().String(name, "", param.Description)
-                        }
+			switch param.Type {
+			case "string":
+				subtoolCmd.Flags().String(name, "", param.Description)
+			case "int", "number":
+				subtoolCmd.Flags().Int(name, 0, param.Description)
+			case "bool", "boolean":
+				subtoolCmd.Flags().Bool(name, false, param.Description)
+			default:
+				// Default to string for unknown types
+				subtoolCmd.Flags().String(name, "", param.Description)
+			}
 
-                        if param.Required {
-                                subtoolCmd.MarkFlagRequired(name)
-                        }
-                }
+			if param.Required {
+				subtoolCmd.MarkFlagRequired(name)
+			}
+		}
 
-                toolCmd.AddCommand(subtoolCmd)
-        }
+		toolCmd.AddCommand(subtoolCmd)
+	}
 
-        return toolCmd
+	return toolCmd
 }
 
 func createSubtoolCommand(parentName string, subtool config.Subtool) *cobra.Command {
-        // Replace spaces with underscores in the name
-        name := strings.ReplaceAll(subtool.Name, " ", "_")
-        fullName := parentName + "_" + name
+	// Replace spaces with underscores in the name
+	name := strings.ReplaceAll(subtool.Name, " ", "_")
+	fullName := parentName + "_" + name
 
-        subtoolCmd := &cobra.Command{
-                Use:   name,
-                Short: fmt.Sprintf("Execute %s command", fullName),
-                Run: func(cmd *cobra.Command, args []string) {
-                        // If no subtools, execute the subtool
-                        if len(subtool.Subtools) == 0 {
-                                // Get parameter values from both the parent tool and this subtool
-                                paramValues := getParamValues(cmd, subtool.Params)
-                                if err := toolMgr.ExecuteTool(fullName, paramValues); err != nil {
-                                        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-                                        os.Exit(1)
-                                }
-                                return
-                        }
+	subtoolCmd := &cobra.Command{
+		Use:   name,
+		Short: fmt.Sprintf("Execute %s command", fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			// If no subtools, execute the subtool
+			if len(subtool.Subtools) == 0 {
+				// Get parameter values from both the parent tool and this subtool
+				paramValues := getParamValues(cmd, subtool.Params)
+				if err := toolMgr.ExecuteTool(fullName, paramValues); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
 
-                        // Otherwise, show help
-                        cmd.Help()
-                },
-        }
+			// Otherwise, show help
+			cmd.Help()
+		},
+	}
 
-        // Add flags for subtool parameters
-        addParamFlags(subtoolCmd, subtool.Params)
+	// Add flags for subtool parameters
+	addParamFlags(subtoolCmd, subtool.Params)
 
-        // Add subcommands for each nested subtool
-        for _, nestedSubtool := range subtool.Subtools {
-                nestedCmd := createSubtoolCommand(fullName, nestedSubtool)
-                subtoolCmd.AddCommand(nestedCmd)
-        }
+	// Add subcommands for each nested subtool
+	for _, nestedSubtool := range subtool.Subtools {
+		nestedCmd := createSubtoolCommand(fullName, nestedSubtool)
+		subtoolCmd.AddCommand(nestedCmd)
+	}
 
-        return subtoolCmd
+	return subtoolCmd
 }
 
 func addParamFlags(cmd *cobra.Command, params config.Parameters) {
-        for name, param := range params {
-                switch param.Type {
-                case "string":
-                        cmd.Flags().String(name, "", param.Description)
-                case "int", "number":
-                        cmd.Flags().Int(name, 0, param.Description)
-                case "bool", "boolean":
-                        cmd.Flags().Bool(name, false, param.Description)
-                default:
-                        // Default to string for unknown types
-                        cmd.Flags().String(name, "", param.Description)
-                }
+	for name, param := range params {
+		switch param.Type {
+		case "string":
+			cmd.Flags().String(name, "", param.Description)
+		case "int", "number":
+			cmd.Flags().Int(name, 0, param.Description)
+		case "bool", "boolean":
+			cmd.Flags().Bool(name, false, param.Description)
+		default:
+			// Default to string for unknown types
+			cmd.Flags().String(name, "", param.Description)
+		}
 
-                if param.Required {
-                        cmd.MarkFlagRequired(name)
-                }
-        }
+		if param.Required {
+			cmd.MarkFlagRequired(name)
+		}
+	}
 }
 
 func getParamValues(cmd *cobra.Command, params config.Parameters) map[string]string {
-        result := make(map[string]string)
+	result := make(map[string]string)
 
-        // Get all flags from the current command and all parent commands
-        cmd.Flags().Visit(func(flag *pflag.Flag) {
-                result[flag.Name] = flag.Value.String()
-        })
+	// Get all flags from the current command and all parent commands
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		result[flag.Name] = flag.Value.String()
+	})
 
-        // Get all persistent flags
-        cmd.PersistentFlags().Visit(func(flag *pflag.Flag) {
-                result[flag.Name] = flag.Value.String()
-        })
+	// Get all persistent flags
+	cmd.PersistentFlags().Visit(func(flag *pflag.Flag) {
+		result[flag.Name] = flag.Value.String()
+	})
 
-        // Get flags from parent commands
-        parent := cmd.Parent()
-        for parent != nil {
-                parent.Flags().Visit(func(flag *pflag.Flag) {
-                        result[flag.Name] = flag.Value.String()
-                })
-                parent.PersistentFlags().Visit(func(flag *pflag.Flag) {
-                        result[flag.Name] = flag.Value.String()
-                })
-                parent = parent.Parent()
-        }
+	// Get flags from parent commands
+	parent := cmd.Parent()
+	for parent != nil {
+		parent.Flags().Visit(func(flag *pflag.Flag) {
+			result[flag.Name] = flag.Value.String()
+		})
+		parent.PersistentFlags().Visit(func(flag *pflag.Flag) {
+			result[flag.Name] = flag.Value.String()
+		})
+		parent = parent.Parent()
+	}
 
-        return result
+	return result
 }
 
 // printSubtools displays subtools in a hierarchical format
 func printSubtools(subtools []tool.Info, level int, parentPath string, verbose bool) {
-        indent := strings.Repeat("  ", level) // Indent based on level
-        prefix := indent + "└─ "
+	indent := strings.Repeat("  ", level) // Indent based on level
+	prefix := indent + "└─ "
 
-        for _, subtool := range subtools {
-                // Build the full path name
-                fullPath := parentPath + "_" + subtool.Name
+	for _, subtool := range subtools {
+		// Build the full path name
+		fullPath := parentPath + "_" + subtool.Name
 
-                // Display subtool name and full path
-                fmt.Printf("%s%s (%s)\n", prefix, subtool.Name, fullPath)
+		// Display subtool name and full path
+		fmt.Printf("%s%s (%s)\n", prefix, subtool.Name, fullPath)
 
-                // If verbose mode, display parameter information
-                if verbose && len(subtool.Params) > 0 {
-                        paramIndent := indent + "   " + "  " // Indent for parameters
-                        fmt.Printf("%sParameters:\n", paramIndent)
+		// If verbose mode, display parameter information
+		if verbose && len(subtool.Params) > 0 {
+			paramIndent := indent + "   " + "  " // Indent for parameters
+			fmt.Printf("%sParameters:\n", paramIndent)
 
-                        for name, param := range subtool.Params {
-                                required := ""
-                                if param.Required {
-                                        required = " (required)"
-                                }
-                                fmt.Printf("%s  --%s%s: %s\n", paramIndent, name, required, param.Description)
-                        }
-                }
+			for name, param := range subtool.Params {
+				required := ""
+				if param.Required {
+					required = " (required)"
+				}
+				fmt.Printf("%s  --%s%s: %s\n", paramIndent, name, required, param.Description)
+			}
+		}
 
-                // Display nested subtools
-                printSubtools(subtool.Subtools, level+1, fullPath, verbose)
-        }
+		// Display nested subtools
+		printSubtools(subtool.Subtools, level+1, fullPath, verbose)
+	}
 }

--- a/cmd/operations/main.go
+++ b/cmd/operations/main.go
@@ -1,364 +1,364 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"strings"
-	"time"
+        "fmt"
+        "os"
+        "strings"
+        "time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/takutakahashi/operation-mcp/pkg/config"
-	"github.com/takutakahashi/operation-mcp/pkg/tool"
+        "github.com/spf13/cobra"
+        "github.com/spf13/pflag"
+        "github.com/takutakahashi/operation-mcp/pkg/config"
+        "github.com/takutakahashi/operation-mcp/pkg/tool"
 )
 
 var (
-	configPath string
-	cfg        *config.Config
-	toolMgr    *tool.Manager
+        configPath string
+        cfg        *config.Config
+        toolMgr    *tool.Manager
 
-	// SSH関連のフラグ
-	remoteMode    bool
-	sshHost       string
-	sshUser       string
-	sshKeyPath    string
-	sshPassword   string
-	sshPort       int
-	sshTimeout    time.Duration
-	sshVerifyHost bool
+        // SSH関連のフラグ
+        remoteMode    bool
+        sshHost       string
+        sshUser       string
+        sshKeyPath    string
+        sshPassword   string
+        sshPort       int
+        sshTimeout    time.Duration
+        sshVerifyHost bool
 )
 
 func main() {
-	// Parse config from flags directly to handle it early
-	for i, arg := range os.Args {
-		if strings.HasPrefix(arg, "--config=") {
-			configPath = strings.TrimPrefix(arg, "--config=")
-			break
-		} else if arg == "--config" && i+1 < len(os.Args) {
-			configPath = os.Args[i+1]
-			break
-		}
-	}
+        // Parse config from flags directly to handle it early
+        for i, arg := range os.Args {
+                if strings.HasPrefix(arg, "--config=") {
+                        configPath = strings.TrimPrefix(arg, "--config=")
+                        break
+                } else if arg == "--config" && i+1 < len(os.Args) {
+                        configPath = os.Args[i+1]
+                        break
+                }
+        }
 
-	// Try to load the config early
-	var err error
-	if configPath != "" {
-		cfg, err = config.LoadConfig(configPath)
-		if err != nil {
-			fmt.Printf("Warning: Failed to load config from %s: %v\n", configPath, err)
-		}
-	}
+        // Try to load the config early
+        var err error
+        if configPath != "" {
+                cfg, err = config.LoadConfig(configPath)
+                if err != nil {
+                        fmt.Printf("Warning: Failed to load config from %s: %v\n", configPath, err)
+                }
+        }
 
-	rootCmd := &cobra.Command{
-		Use:   "operations",
-		Short: "Operations CLI tool",
-		Long:  "A CLI tool for executing operations defined in a configuration file",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// If we already loaded the config, we can skip this
-			if cfg != nil {
-				return nil
-			}
+        rootCmd := &cobra.Command{
+                Use:   "operations",
+                Short: "Operations CLI tool",
+                Long:  "A CLI tool for executing operations defined in a configuration file",
+                PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+                        // If we already loaded the config, we can skip this
+                        if cfg != nil {
+                                return nil
+                        }
 
-			var err error
-			cfg, err = config.LoadConfig(configPath)
-			if err != nil {
-				return fmt.Errorf("failed to load config: %w", err)
-			}
+                        var err error
+                        cfg, err = config.LoadConfig(configPath)
+                        if err != nil {
+                                return fmt.Errorf("failed to load config: %w", err)
+                        }
 
-			if err := cfg.Validate(); err != nil {
-				return fmt.Errorf("invalid configuration: %w", err)
-			}
+                        if err := cfg.Validate(); err != nil {
+                                return fmt.Errorf("invalid configuration: %w", err)
+                        }
 
-			// Create and configure the tool manager
-			toolMgr = tool.NewManager(cfg)
+                        // Create and configure the tool manager
+                        toolMgr = tool.NewManager(cfg)
 
-			// Create the appropriate executor based on flags
-			exec, err := createExecutor()
-			if err != nil {
-				return fmt.Errorf("failed to create executor: %w", err)
-			}
+                        // Create the appropriate executor based on flags
+                        exec, err := createExecutor()
+                        if err != nil {
+                                return fmt.Errorf("failed to create executor: %w", err)
+                        }
 
-			// Set executor for the tool manager
-			toolMgr.WithExecutor(exec)
+                        // Set executor for the tool manager
+                        toolMgr.WithExecutor(exec)
 
-			return nil
-		},
-	}
+                        return nil
+                },
+        }
 
-	rootCmd.PersistentFlags().StringVar(&configPath, "config", configPath, "path to config file")
+        rootCmd.PersistentFlags().StringVar(&configPath, "config", configPath, "path to config file")
 
-	// SSH関連のフラグを追加
-	rootCmd.PersistentFlags().BoolVar(&remoteMode, "remote", false, "Enable remote execution mode via SSH")
-	rootCmd.PersistentFlags().StringVar(&sshHost, "host", "", "SSH remote host")
-	rootCmd.PersistentFlags().StringVar(&sshUser, "user", "", "SSH username")
-	rootCmd.PersistentFlags().StringVar(&sshKeyPath, "key", "", "Path to SSH private key")
-	rootCmd.PersistentFlags().StringVar(&sshPassword, "password", "", "SSH password (not recommended)")
-	rootCmd.PersistentFlags().IntVar(&sshPort, "port", 22, "SSH port")
-	rootCmd.PersistentFlags().DurationVar(&sshTimeout, "timeout", 10*time.Second, "SSH connection timeout")
-	rootCmd.PersistentFlags().BoolVar(&sshVerifyHost, "verify-host", true, "Verify host key")
+        // SSH関連のフラグを追加
+        rootCmd.PersistentFlags().BoolVar(&remoteMode, "remote", false, "Enable remote execution mode via SSH")
+        rootCmd.PersistentFlags().StringVar(&sshHost, "host", "", "SSH remote host")
+        rootCmd.PersistentFlags().StringVar(&sshUser, "user", "", "SSH username")
+        rootCmd.PersistentFlags().StringVar(&sshKeyPath, "key", "", "Path to SSH private key")
+        rootCmd.PersistentFlags().StringVar(&sshPassword, "password", "", "SSH password (not recommended)")
+        rootCmd.PersistentFlags().IntVar(&sshPort, "port", 22, "SSH port")
+        rootCmd.PersistentFlags().DurationVar(&sshTimeout, "timeout", 10*time.Second, "SSH connection timeout")
+        rootCmd.PersistentFlags().BoolVar(&sshVerifyHost, "verify-host", true, "Verify host key")
 
-	// Add the exec command
-	execCmd := &cobra.Command{
-		Use:   "exec [tool_subtool] [args...]",
-		Short: "Execute a specific subtool with parameters",
-		Long:  `Execute a tool's subtool with parameters. The tool_subtool must be specified in the format "tool_subtool", e.g. "kubectl_get_pod".`,
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			toolPath := args[0]
-			toolArgs := []string{}
-			if len(args) > 1 {
-				toolArgs = args[1:]
-			}
+        // Add the exec command
+        execCmd := &cobra.Command{
+                Use:   "exec [tool_subtool] [args...]",
+                Short: "Execute a specific subtool with parameters",
+                Long:  `Execute a tool's subtool with parameters. The tool_subtool must be specified in the format "tool_subtool", e.g. "kubectl_get_pod".`,
+                Args:  cobra.MinimumNArgs(1),
+                Run: func(cmd *cobra.Command, args []string) {
+                        toolPath := args[0]
+                        toolArgs := []string{}
+                        if len(args) > 1 {
+                                toolArgs = args[1:]
+                        }
 
-			if err := toolMgr.ExecuteRawTool(toolPath, toolArgs); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-		},
-	}
+                        if err := toolMgr.ExecuteRawTool(toolPath, toolArgs); err != nil {
+                                fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+                                os.Exit(1)
+                        }
+                },
+        }
 
-	rootCmd.AddCommand(execCmd)
+        rootCmd.AddCommand(execCmd)
 
-	// Add the list command
-	listCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all available tools",
-		Long:  `List all available tools and their subtools defined in the configuration file`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// If toolMgr is nil, we couldn't load a config
-			if toolMgr == nil {
-				fmt.Println("No tools available. Please provide a valid configuration file.")
-				return
-			}
+        // Add the list command
+        listCmd := &cobra.Command{
+                Use:   "list",
+                Short: "List all available tools",
+                Long:  `List all available tools and their subtools defined in the configuration file`,
+                Run: func(cmd *cobra.Command, args []string) {
+                        // If toolMgr is nil, we couldn't load a config
+                        if toolMgr == nil {
+                                fmt.Println("No tools available. Please provide a valid configuration file.")
+                                return
+                        }
 
-			// Get verbose flag
-			verbose, _ := cmd.Flags().GetBool("verbose")
+                        // Get verbose flag
+                        verbose, _ := cmd.Flags().GetBool("verbose")
 
-			// Get tools list
-			tools := toolMgr.ListTools()
+                        // Get tools list
+                        tools := toolMgr.ListTools()
 
-			// Display header
-			fmt.Println("Available tools:")
-			fmt.Println()
+                        // Display header
+                        fmt.Println("Available tools:")
+                        fmt.Println()
 
-			// Display tools
-			for _, tool := range tools {
-				fmt.Println(tool.Name)
+                        // Display tools
+                        for _, tool := range tools {
+                                fmt.Println(tool.Name)
 
-				// Display subtools recursively
-				printSubtools(tool.Subtools, 1, tool.Name, verbose)
+                                // Display subtools recursively
+                                printSubtools(tool.Subtools, 1, tool.Name, verbose)
 
-				fmt.Println() // Empty line between tools
-			}
-		},
-	}
+                                fmt.Println() // Empty line between tools
+                        }
+                },
+        }
 
-	// Add verbose flag
-	listCmd.Flags().BoolP("verbose", "v", false, "Show detailed information including parameters")
+        // Add verbose flag
+        listCmd.Flags().BoolP("verbose", "v", false, "Show detailed information including parameters")
 
-	rootCmd.AddCommand(listCmd)
+        rootCmd.AddCommand(listCmd)
 
-	// If we have a config, add commands for each tool
-	if cfg != nil {
-		// Create and configure the tool manager
-		toolMgr = tool.NewManager(cfg)
+        // If we have a config, add commands for each tool
+        if cfg != nil {
+                // Create and configure the tool manager
+                toolMgr = tool.NewManager(cfg)
 
-		// Create the appropriate executor based on flags
-		exec, err := createExecutor()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to create executor: %v\n", err)
-		} else {
-			// Set executor for the tool manager
-			toolMgr.WithExecutor(exec)
-		}
+                // Create the appropriate executor based on flags
+                exec, err := createExecutor()
+                if err != nil {
+                        fmt.Fprintf(os.Stderr, "Warning: Failed to create executor: %v\n", err)
+                } else {
+                        // Set executor for the tool manager
+                        toolMgr.WithExecutor(exec)
+                }
 
-		for _, tool := range cfg.Tools {
-			toolCmd := createToolCommand(tool)
-			rootCmd.AddCommand(toolCmd)
-		}
-	}
+                for _, tool := range cfg.Tools {
+                        toolCmd := createToolCommand(tool)
+                        rootCmd.AddCommand(toolCmd)
+                }
+        }
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+        if err := rootCmd.Execute(); err != nil {
+                fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+                os.Exit(1)
+        }
 }
 
 func createToolCommand(tool config.Tool) *cobra.Command {
-	toolCmd := &cobra.Command{
-		Use:   tool.Name,
-		Short: fmt.Sprintf("Execute %s command", tool.Name),
-		Run: func(cmd *cobra.Command, args []string) {
-			// If no subtools, execute the tool directly
-			if len(tool.Subtools) == 0 {
-				paramValues := getParamValues(cmd, tool.Params)
-				if err := toolMgr.ExecuteTool(tool.Name, paramValues); err != nil {
-					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-					os.Exit(1)
-				}
-				return
-			}
+        toolCmd := &cobra.Command{
+                Use:   tool.Name,
+                Short: fmt.Sprintf("Execute %s command", tool.Name),
+                Run: func(cmd *cobra.Command, args []string) {
+                        // If no subtools, execute the tool directly
+                        if len(tool.Subtools) == 0 {
+                                paramValues := getParamValues(cmd, tool.Params)
+                                if err := toolMgr.ExecuteTool(tool.Name, paramValues); err != nil {
+                                        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+                                        os.Exit(1)
+                                }
+                                return
+                        }
 
-			// Otherwise, show help
-			cmd.Help()
-		},
-	}
+                        // Otherwise, show help
+                        cmd.Help()
+                },
+        }
 
-	// Add flags for tool parameters
-	addParamFlags(toolCmd, tool.Params)
+        // Add flags for tool parameters
+        addParamFlags(toolCmd, tool.Params)
 
-	// Add subcommands for each subtool
-	for _, subtool := range tool.Subtools {
-		subtoolCmd := createSubtoolCommand(tool.Name, subtool)
+        // Add subcommands for each subtool
+        for _, subtool := range tool.Subtools {
+                subtoolCmd := createSubtoolCommand(tool.Name, subtool)
 
-		// Add parent tool's parameters to subtool command
-		for name, param := range tool.Params {
-			// Skip adding the flag if it already exists
-			exists := false
-			subtoolCmd.Flags().VisitAll(func(flag *pflag.Flag) {
-				if flag.Name == name {
-					exists = true
-				}
-			})
-			if exists {
-				continue
-			}
+                // Add parent tool's parameters to subtool command
+                for name, param := range tool.Params {
+                        // Skip adding the flag if it already exists
+                        exists := false
+                        subtoolCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+                                if flag.Name == name {
+                                        exists = true
+                                }
+                        })
+                        if exists {
+                                continue
+                        }
 
-			switch param.Type {
-			case "string":
-				subtoolCmd.Flags().String(name, "", param.Description)
-			case "int", "number":
-				subtoolCmd.Flags().Int(name, 0, param.Description)
-			case "bool", "boolean":
-				subtoolCmd.Flags().Bool(name, false, param.Description)
-			default:
-				// Default to string for unknown types
-				subtoolCmd.Flags().String(name, "", param.Description)
-			}
+                        switch param.Type {
+                        case "string":
+                                subtoolCmd.Flags().String(name, "", param.Description)
+                        case "int", "number":
+                                subtoolCmd.Flags().Int(name, 0, param.Description)
+                        case "bool", "boolean":
+                                subtoolCmd.Flags().Bool(name, false, param.Description)
+                        default:
+                                // Default to string for unknown types
+                                subtoolCmd.Flags().String(name, "", param.Description)
+                        }
 
-			if param.Required {
-				subtoolCmd.MarkFlagRequired(name)
-			}
-		}
+                        if param.Required {
+                                subtoolCmd.MarkFlagRequired(name)
+                        }
+                }
 
-		toolCmd.AddCommand(subtoolCmd)
-	}
+                toolCmd.AddCommand(subtoolCmd)
+        }
 
-	return toolCmd
+        return toolCmd
 }
 
 func createSubtoolCommand(parentName string, subtool config.Subtool) *cobra.Command {
-	// Replace spaces with underscores in the name
-	name := strings.ReplaceAll(subtool.Name, " ", "_")
-	fullName := parentName + "_" + name
+        // Replace spaces with underscores in the name
+        name := strings.ReplaceAll(subtool.Name, " ", "_")
+        fullName := parentName + "_" + name
 
-	subtoolCmd := &cobra.Command{
-		Use:   name,
-		Short: fmt.Sprintf("Execute %s command", fullName),
-		Run: func(cmd *cobra.Command, args []string) {
-			// If no subtools, execute the subtool
-			if len(subtool.Subtools) == 0 {
-				// Get parameter values from both the parent tool and this subtool
-				paramValues := getParamValues(cmd, subtool.Params)
-				if err := toolMgr.ExecuteTool(fullName, paramValues); err != nil {
-					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-					os.Exit(1)
-				}
-				return
-			}
+        subtoolCmd := &cobra.Command{
+                Use:   name,
+                Short: fmt.Sprintf("Execute %s command", fullName),
+                Run: func(cmd *cobra.Command, args []string) {
+                        // If no subtools, execute the subtool
+                        if len(subtool.Subtools) == 0 {
+                                // Get parameter values from both the parent tool and this subtool
+                                paramValues := getParamValues(cmd, subtool.Params)
+                                if err := toolMgr.ExecuteTool(fullName, paramValues); err != nil {
+                                        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+                                        os.Exit(1)
+                                }
+                                return
+                        }
 
-			// Otherwise, show help
-			cmd.Help()
-		},
-	}
+                        // Otherwise, show help
+                        cmd.Help()
+                },
+        }
 
-	// Add flags for subtool parameters
-	addParamFlags(subtoolCmd, subtool.Params)
+        // Add flags for subtool parameters
+        addParamFlags(subtoolCmd, subtool.Params)
 
-	// Add subcommands for each nested subtool
-	for _, nestedSubtool := range subtool.Subtools {
-		nestedCmd := createSubtoolCommand(fullName, nestedSubtool)
-		subtoolCmd.AddCommand(nestedCmd)
-	}
+        // Add subcommands for each nested subtool
+        for _, nestedSubtool := range subtool.Subtools {
+                nestedCmd := createSubtoolCommand(fullName, nestedSubtool)
+                subtoolCmd.AddCommand(nestedCmd)
+        }
 
-	return subtoolCmd
+        return subtoolCmd
 }
 
 func addParamFlags(cmd *cobra.Command, params config.Parameters) {
-	for name, param := range params {
-		switch param.Type {
-		case "string":
-			cmd.Flags().String(name, "", param.Description)
-		case "int", "number":
-			cmd.Flags().Int(name, 0, param.Description)
-		case "bool", "boolean":
-			cmd.Flags().Bool(name, false, param.Description)
-		default:
-			// Default to string for unknown types
-			cmd.Flags().String(name, "", param.Description)
-		}
+        for name, param := range params {
+                switch param.Type {
+                case "string":
+                        cmd.Flags().String(name, "", param.Description)
+                case "int", "number":
+                        cmd.Flags().Int(name, 0, param.Description)
+                case "bool", "boolean":
+                        cmd.Flags().Bool(name, false, param.Description)
+                default:
+                        // Default to string for unknown types
+                        cmd.Flags().String(name, "", param.Description)
+                }
 
-		if param.Required {
-			cmd.MarkFlagRequired(name)
-		}
-	}
+                if param.Required {
+                        cmd.MarkFlagRequired(name)
+                }
+        }
 }
 
 func getParamValues(cmd *cobra.Command, params config.Parameters) map[string]string {
-	result := make(map[string]string)
+        result := make(map[string]string)
 
-	// Get all flags from the current command and all parent commands
-	cmd.Flags().Visit(func(flag *pflag.Flag) {
-		result[flag.Name] = flag.Value.String()
-	})
+        // Get all flags from the current command and all parent commands
+        cmd.Flags().Visit(func(flag *pflag.Flag) {
+                result[flag.Name] = flag.Value.String()
+        })
 
-	// Get all persistent flags
-	cmd.PersistentFlags().Visit(func(flag *pflag.Flag) {
-		result[flag.Name] = flag.Value.String()
-	})
+        // Get all persistent flags
+        cmd.PersistentFlags().Visit(func(flag *pflag.Flag) {
+                result[flag.Name] = flag.Value.String()
+        })
 
-	// Get flags from parent commands
-	parent := cmd.Parent()
-	for parent != nil {
-		parent.Flags().Visit(func(flag *pflag.Flag) {
-			result[flag.Name] = flag.Value.String()
-		})
-		parent.PersistentFlags().Visit(func(flag *pflag.Flag) {
-			result[flag.Name] = flag.Value.String()
-		})
-		parent = parent.Parent()
-	}
+        // Get flags from parent commands
+        parent := cmd.Parent()
+        for parent != nil {
+                parent.Flags().Visit(func(flag *pflag.Flag) {
+                        result[flag.Name] = flag.Value.String()
+                })
+                parent.PersistentFlags().Visit(func(flag *pflag.Flag) {
+                        result[flag.Name] = flag.Value.String()
+                })
+                parent = parent.Parent()
+        }
 
-	return result
+        return result
 }
 
 // printSubtools displays subtools in a hierarchical format
-func printSubtools(subtools []tool.ToolInfo, level int, parentPath string, verbose bool) {
-	indent := strings.Repeat("  ", level) // Indent based on level
-	prefix := indent + "└─ "
+func printSubtools(subtools []tool.Info, level int, parentPath string, verbose bool) {
+        indent := strings.Repeat("  ", level) // Indent based on level
+        prefix := indent + "└─ "
 
-	for _, subtool := range subtools {
-		// Build the full path name
-		fullPath := parentPath + "_" + subtool.Name
+        for _, subtool := range subtools {
+                // Build the full path name
+                fullPath := parentPath + "_" + subtool.Name
 
-		// Display subtool name and full path
-		fmt.Printf("%s%s (%s)\n", prefix, subtool.Name, fullPath)
+                // Display subtool name and full path
+                fmt.Printf("%s%s (%s)\n", prefix, subtool.Name, fullPath)
 
-		// If verbose mode, display parameter information
-		if verbose && len(subtool.Params) > 0 {
-			paramIndent := indent + "   " + "  " // Indent for parameters
-			fmt.Printf("%sParameters:\n", paramIndent)
+                // If verbose mode, display parameter information
+                if verbose && len(subtool.Params) > 0 {
+                        paramIndent := indent + "   " + "  " // Indent for parameters
+                        fmt.Printf("%sParameters:\n", paramIndent)
 
-			for name, param := range subtool.Params {
-				required := ""
-				if param.Required {
-					required = " (required)"
-				}
-				fmt.Printf("%s  --%s%s: %s\n", paramIndent, name, required, param.Description)
-			}
-		}
+                        for name, param := range subtool.Params {
+                                required := ""
+                                if param.Required {
+                                        required = " (required)"
+                                }
+                                fmt.Printf("%s  --%s%s: %s\n", paramIndent, name, required, param.Description)
+                        }
+                }
 
-		// Display nested subtools
-		printSubtools(subtool.Subtools, level+1, fullPath, verbose)
-	}
+                // Display nested subtools
+                printSubtools(subtool.Subtools, level+1, fullPath, verbose)
+        }
 }

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -1,328 +1,328 @@
 package tool
 
 import (
-        "bytes"
-        "fmt"
-        "os"
-        "os/exec"
-        "strings"
-        "text/template"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/template"
 
-        "github.com/takutakahashi/operation-mcp/pkg/config"
-        "github.com/takutakahashi/operation-mcp/pkg/danger"
-        "github.com/takutakahashi/operation-mcp/pkg/executor"
+	"github.com/takutakahashi/operation-mcp/pkg/config"
+	"github.com/takutakahashi/operation-mcp/pkg/danger"
+	"github.com/takutakahashi/operation-mcp/pkg/executor"
 )
 
 // Info represents a tool or subtool for hierarchical display
 type Info struct {
-        Name        string
-        Description string
-        Params      map[string]config.Parameter
-        Subtools    []Info
+	Name        string
+	Description string
+	Params      map[string]config.Parameter
+	Subtools    []Info
 }
 
 // Manager handles tool execution
 type Manager struct {
-        config        *config.Config
-        dangerManager *danger.Manager
-        execInstance  executor.Executor
+	config        *config.Config
+	dangerManager *danger.Manager
+	execInstance  executor.Executor
 }
 
 // NewManager creates a new tool manager
 func NewManager(cfg *config.Config) *Manager {
-        return &Manager{
-                config:        cfg,
-                dangerManager: danger.NewManager(cfg.Actions),
-        }
+	return &Manager{
+		config:        cfg,
+		dangerManager: danger.NewManager(cfg.Actions),
+	}
 }
 
 // WithExecutor sets the executor for the tool manager
 func (m *Manager) WithExecutor(exec executor.Executor) {
-        m.execInstance = exec
+	m.execInstance = exec
 }
 
 // FindTool finds a tool by its name
 func (m *Manager) FindTool(toolPath string) ([]string, map[string]config.Parameter, string, error) {
-        parts := strings.Split(toolPath, "_")
-        if len(parts) < 1 {
-                return nil, nil, "", fmt.Errorf("invalid tool path: %s", toolPath)
-        }
+	parts := strings.Split(toolPath, "_")
+	if len(parts) < 1 {
+		return nil, nil, "", fmt.Errorf("invalid tool path: %s", toolPath)
+	}
 
-        // Find the root tool
-        var rootTool *config.Tool
-        for i := range m.config.Tools {
-                if m.config.Tools[i].Name == parts[0] {
-                        rootTool = &m.config.Tools[i]
-                        break
-                }
-        }
+	// Find the root tool
+	var rootTool *config.Tool
+	for i := range m.config.Tools {
+		if m.config.Tools[i].Name == parts[0] {
+			rootTool = &m.config.Tools[i]
+			break
+		}
+	}
 
-        if rootTool == nil {
-                return nil, nil, "", fmt.Errorf("tool not found: %s", parts[0])
-        }
+	if rootTool == nil {
+		return nil, nil, "", fmt.Errorf("tool not found: %s", parts[0])
+	}
 
-        // Start with the root tool's command
-        command := make([]string, len(rootTool.Command))
-        copy(command, rootTool.Command)
+	// Start with the root tool's command
+	command := make([]string, len(rootTool.Command))
+	copy(command, rootTool.Command)
 
-        // Collect all parameters
-        params := make(map[string]config.Parameter)
-        for name, param := range rootTool.Params {
-                params[name] = param
-        }
+	// Collect all parameters
+	params := make(map[string]config.Parameter)
+	for name, param := range rootTool.Params {
+		params[name] = param
+	}
 
-        // If we only have the root tool, return it
-        if len(parts) == 1 {
-                return command, params, "", nil
-        }
+	// If we only have the root tool, return it
+	if len(parts) == 1 {
+		return command, params, "", nil
+	}
 
-        // Navigate through subtools
-        var currentSubtool *config.Subtool
-        dangerLevel := ""
+	// Navigate through subtools
+	var currentSubtool *config.Subtool
+	dangerLevel := ""
 
-        // Join the remaining parts to form the subtool path
-        subtoolPath := strings.Join(parts[1:], "_")
+	// Join the remaining parts to form the subtool path
+	subtoolPath := strings.Join(parts[1:], "_")
 
-        // Find the matching subtool
-        found := false
-        for j := range rootTool.Subtools {
-                subtoolName := strings.ReplaceAll(rootTool.Subtools[j].Name, " ", "_")
-                if subtoolName == subtoolPath {
-                        currentSubtool = &rootTool.Subtools[j]
-                        found = true
-                        break
-                }
-        }
+	// Find the matching subtool
+	found := false
+	for j := range rootTool.Subtools {
+		subtoolName := strings.ReplaceAll(rootTool.Subtools[j].Name, " ", "_")
+		if subtoolName == subtoolPath {
+			currentSubtool = &rootTool.Subtools[j]
+			found = true
+			break
+		}
+	}
 
-        if !found {
-                return nil, nil, "", fmt.Errorf("subtool not found: %s", toolPath)
-        }
+	if !found {
+		return nil, nil, "", fmt.Errorf("subtool not found: %s", toolPath)
+	}
 
-        // Add subtool parameters
-        for name, param := range currentSubtool.Params {
-                params[name] = param
-        }
+	// Add subtool parameters
+	for name, param := range currentSubtool.Params {
+		params[name] = param
+	}
 
-        // Update danger level if specified
-        if currentSubtool.DangerLevel != "" {
-                dangerLevel = currentSubtool.DangerLevel
-        }
+	// Update danger level if specified
+	if currentSubtool.DangerLevel != "" {
+		dangerLevel = currentSubtool.DangerLevel
+	}
 
-        // Add the args from the final subtool
-        if currentSubtool != nil {
-                command = append(command, currentSubtool.Args...)
-        }
+	// Add the args from the final subtool
+	if currentSubtool != nil {
+		command = append(command, currentSubtool.Args...)
+	}
 
-        return command, params, dangerLevel, nil
+	return command, params, dangerLevel, nil
 }
 
 // ExecuteTool executes a tool with the given parameters
 func (m *Manager) ExecuteTool(toolPath string, paramValues map[string]string) error {
-        // Find the tool
-        command, params, dangerLevel, err := m.FindTool(toolPath)
-        if err != nil {
-                return err
-        }
+	// Find the tool
+	command, params, dangerLevel, err := m.FindTool(toolPath)
+	if err != nil {
+		return err
+	}
 
-        // Validate required parameters
-        for name, param := range params {
-                if param.Required {
-                        value, exists := paramValues[name]
-                        if !exists || value == "" {
-                                return fmt.Errorf("required parameter missing: %s", name)
-                        }
-                }
-        }
+	// Validate required parameters
+	for name, param := range params {
+		if param.Required {
+			value, exists := paramValues[name]
+			if !exists || value == "" {
+				return fmt.Errorf("required parameter missing: %s", name)
+			}
+		}
+	}
 
-        // Check danger level for parameters with validation rules
-        for name, param := range params {
-                value, exists := paramValues[name]
-                if exists && len(param.Validate) > 0 {
-                        for _, validation := range param.Validate {
-                                proceed, err := m.dangerManager.CheckDangerLevel(
-                                        validation.DangerLevel,
-                                        name,
-                                        value,
-                                        param.Validate,
-                                )
-                                if err != nil {
-                                        return err
-                                }
-                                if !proceed {
-                                        return fmt.Errorf("operation aborted due to danger level check")
-                                }
-                        }
-                }
-        }
+	// Check danger level for parameters with validation rules
+	for name, param := range params {
+		value, exists := paramValues[name]
+		if exists && len(param.Validate) > 0 {
+			for _, validation := range param.Validate {
+				proceed, err := m.dangerManager.CheckDangerLevel(
+					validation.DangerLevel,
+					name,
+					value,
+					param.Validate,
+				)
+				if err != nil {
+					return err
+				}
+				if !proceed {
+					return fmt.Errorf("operation aborted due to danger level check")
+				}
+			}
+		}
+	}
 
-        // Check danger level for the tool itself
-        if dangerLevel != "" {
-                proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
-                if err != nil {
-                        return err
-                }
-                if !proceed {
-                        return fmt.Errorf("operation aborted due to danger level check")
-                }
-        }
+	// Check danger level for the tool itself
+	if dangerLevel != "" {
+		proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
+		if err != nil {
+			return err
+		}
+		if !proceed {
+			return fmt.Errorf("operation aborted due to danger level check")
+		}
+	}
 
-        // Replace template parameters in command args
-        finalCommand := make([]string, len(command))
-        for i, arg := range command {
-                if strings.Contains(arg, "{{") {
-                        tmpl, err := template.New("arg").Parse(arg)
-                        if err != nil {
-                                return fmt.Errorf("error parsing template in argument: %w", err)
-                        }
+	// Replace template parameters in command args
+	finalCommand := make([]string, len(command))
+	for i, arg := range command {
+		if strings.Contains(arg, "{{") {
+			tmpl, err := template.New("arg").Parse(arg)
+			if err != nil {
+				return fmt.Errorf("error parsing template in argument: %w", err)
+			}
 
-                        var buf bytes.Buffer
-                        if err := tmpl.Execute(&buf, paramValues); err != nil {
-                                return fmt.Errorf("error executing template in argument: %w", err)
-                        }
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, paramValues); err != nil {
+				return fmt.Errorf("error executing template in argument: %w", err)
+			}
 
-                        finalCommand[i] = buf.String()
-                } else {
-                        finalCommand[i] = arg
-                }
-        }
+			finalCommand[i] = buf.String()
+		} else {
+			finalCommand[i] = arg
+		}
+	}
 
-        // Execute the command
-        fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
-        cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
-        cmd.Stdout = os.Stdout
-        cmd.Stderr = os.Stderr
-        cmd.Stdin = os.Stdin
+	// Execute the command
+	fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
+	cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 
-        return cmd.Run()
+	return cmd.Run()
 }
 
 // ExecuteRawTool executes a tool with the given raw arguments
 func (m *Manager) ExecuteRawTool(toolPath string, args []string) error {
-        // Find the tool and subtool
-        command, params, dangerLevel, err := m.FindTool(toolPath)
-        if err != nil {
-                return err
-        }
+	// Find the tool and subtool
+	command, params, dangerLevel, err := m.FindTool(toolPath)
+	if err != nil {
+		return err
+	}
 
-        // Extract parameter values from the command-line arguments
-        paramValues := make(map[string]string)
-        for i := 0; i < len(args); i++ {
-                arg := args[i]
-                if strings.HasPrefix(arg, "-") {
-                        paramName := strings.TrimLeft(arg, "-")
-                        // Handle --param=value format
-                        if strings.Contains(paramName, "=") {
-                                parts := strings.SplitN(paramName, "=", 2)
-                                paramName = parts[0]
-                                paramValues[paramName] = parts[1]
-                                continue
-                        }
+	// Extract parameter values from the command-line arguments
+	paramValues := make(map[string]string)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "-") {
+			paramName := strings.TrimLeft(arg, "-")
+			// Handle --param=value format
+			if strings.Contains(paramName, "=") {
+				parts := strings.SplitN(paramName, "=", 2)
+				paramName = parts[0]
+				paramValues[paramName] = parts[1]
+				continue
+			}
 
-                        // Handle -p value format
-                        if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-                                paramValues[paramName] = args[i+1]
-                                i++ // Skip the next arg since it's the value
-                        } else {
-                                // Handle boolean flags like -f
-                                paramValues[paramName] = "true"
-                        }
-                }
-        }
+			// Handle -p value format
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				paramValues[paramName] = args[i+1]
+				i++ // Skip the next arg since it's the value
+			} else {
+				// Handle boolean flags like -f
+				paramValues[paramName] = "true"
+			}
+		}
+	}
 
-        // Check danger level for the subtool
-        if dangerLevel != "" {
-                proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
-                if err != nil {
-                        return err
-                }
-                if !proceed {
-                        return fmt.Errorf("operation aborted due to danger level check")
-                }
-        }
+	// Check danger level for the subtool
+	if dangerLevel != "" {
+		proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
+		if err != nil {
+			return err
+		}
+		if !proceed {
+			return fmt.Errorf("operation aborted due to danger level check")
+		}
+	}
 
-        // Validate required parameters
-        for name, param := range params {
-                if param.Required {
-                        value, exists := paramValues[name]
-                        if !exists || value == "" {
-                                return fmt.Errorf("required parameter missing: %s", name)
-                        }
-                }
-        }
+	// Validate required parameters
+	for name, param := range params {
+		if param.Required {
+			value, exists := paramValues[name]
+			if !exists || value == "" {
+				return fmt.Errorf("required parameter missing: %s", name)
+			}
+		}
+	}
 
-        // Replace template parameters in command args
-        finalCommand := make([]string, len(command))
-        for i, arg := range command {
-                if strings.Contains(arg, "{{") {
-                        tmpl, err := template.New("arg").Parse(arg)
-                        if err != nil {
-                                return fmt.Errorf("error parsing template in argument: %w", err)
-                        }
+	// Replace template parameters in command args
+	finalCommand := make([]string, len(command))
+	for i, arg := range command {
+		if strings.Contains(arg, "{{") {
+			tmpl, err := template.New("arg").Parse(arg)
+			if err != nil {
+				return fmt.Errorf("error parsing template in argument: %w", err)
+			}
 
-                        var buf bytes.Buffer
-                        if err := tmpl.Execute(&buf, paramValues); err != nil {
-                                return fmt.Errorf("error executing template in argument: %w", err)
-                        }
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, paramValues); err != nil {
+				return fmt.Errorf("error executing template in argument: %w", err)
+			}
 
-                        finalCommand[i] = buf.String()
-                } else {
-                        finalCommand[i] = arg
-                }
-        }
+			finalCommand[i] = buf.String()
+		} else {
+			finalCommand[i] = arg
+		}
+	}
 
-        // Execute the command
-        fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
-        cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
-        cmd.Stdout = os.Stdout
-        cmd.Stderr = os.Stderr
-        cmd.Stdin = os.Stdin
+	// Execute the command
+	fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
+	cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 
-        return cmd.Run()
+	return cmd.Run()
 }
 
 // ListTools returns all tools and subtools defined in the config
 func (m *Manager) ListTools() []Info {
-        if m.config == nil || len(m.config.Tools) == 0 {
-                return []Info{}
-        }
+	if m.config == nil || len(m.config.Tools) == 0 {
+		return []Info{}
+	}
 
-        result := make([]Info, 0, len(m.config.Tools))
+	result := make([]Info, 0, len(m.config.Tools))
 
-        for _, tool := range m.config.Tools {
-                toolInfo := Info{
-                        Name:        tool.Name,
-                        Description: "", // Config doesn't have description field for tools
-                        Params:      tool.Params,
-                        Subtools:    make([]Info, 0, len(tool.Subtools)),
-                }
+	for _, tool := range m.config.Tools {
+		toolInfo := Info{
+			Name:        tool.Name,
+			Description: "", // Config doesn't have description field for tools
+			Params:      tool.Params,
+			Subtools:    make([]Info, 0, len(tool.Subtools)),
+		}
 
-                // Add subtools recursively
-                for _, subtool := range tool.Subtools {
-                        toolInfo.Subtools = append(toolInfo.Subtools, convertSubtoolToInfo(subtool, tool.Name))
-                }
+		// Add subtools recursively
+		for _, subtool := range tool.Subtools {
+			toolInfo.Subtools = append(toolInfo.Subtools, convertSubtoolToInfo(subtool, tool.Name))
+		}
 
-                result = append(result, toolInfo)
-        }
+		result = append(result, toolInfo)
+	}
 
-        return result
+	return result
 }
 
 // convertSubtoolToInfo converts a subtool configuration to Info structure
 func convertSubtoolToInfo(subtool config.Subtool, parentName string) Info {
-        name := strings.ReplaceAll(subtool.Name, " ", "_")
+	name := strings.ReplaceAll(subtool.Name, " ", "_")
 
-        toolInfo := Info{
-                Name:        name,
-                Description: "", // Config doesn't have description field for subtools
-                Params:      subtool.Params,
-                Subtools:    make([]Info, 0, len(subtool.Subtools)),
-        }
+	toolInfo := Info{
+		Name:        name,
+		Description: "", // Config doesn't have description field for subtools
+		Params:      subtool.Params,
+		Subtools:    make([]Info, 0, len(subtool.Subtools)),
+	}
 
-        // Add nested subtools recursively
-        for _, nested := range subtool.Subtools {
-                toolInfo.Subtools = append(toolInfo.Subtools,
-                        convertSubtoolToInfo(nested, parentName+"_"+name))
-        }
+	// Add nested subtools recursively
+	for _, nested := range subtool.Subtools {
+		toolInfo.Subtools = append(toolInfo.Subtools,
+			convertSubtoolToInfo(nested, parentName+"_"+name))
+	}
 
-        return toolInfo
+	return toolInfo
 }

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -1,328 +1,328 @@
 package tool
 
 import (
-	"bytes"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-	"text/template"
+        "bytes"
+        "fmt"
+        "os"
+        "os/exec"
+        "strings"
+        "text/template"
 
-	"github.com/takutakahashi/operation-mcp/pkg/config"
-	"github.com/takutakahashi/operation-mcp/pkg/danger"
-	"github.com/takutakahashi/operation-mcp/pkg/executor"
+        "github.com/takutakahashi/operation-mcp/pkg/config"
+        "github.com/takutakahashi/operation-mcp/pkg/danger"
+        "github.com/takutakahashi/operation-mcp/pkg/executor"
 )
 
-// ToolInfo represents a tool or subtool for hierarchical display
-type ToolInfo struct {
-	Name        string
-	Description string
-	Params      map[string]config.Parameter
-	Subtools    []ToolInfo
+// Info represents a tool or subtool for hierarchical display
+type Info struct {
+        Name        string
+        Description string
+        Params      map[string]config.Parameter
+        Subtools    []Info
 }
 
 // Manager handles tool execution
 type Manager struct {
-	config        *config.Config
-	dangerManager *danger.Manager
-	execInstance  executor.Executor
+        config        *config.Config
+        dangerManager *danger.Manager
+        execInstance  executor.Executor
 }
 
 // NewManager creates a new tool manager
 func NewManager(cfg *config.Config) *Manager {
-	return &Manager{
-		config:        cfg,
-		dangerManager: danger.NewManager(cfg.Actions),
-	}
+        return &Manager{
+                config:        cfg,
+                dangerManager: danger.NewManager(cfg.Actions),
+        }
 }
 
 // WithExecutor sets the executor for the tool manager
 func (m *Manager) WithExecutor(exec executor.Executor) {
-	m.execInstance = exec
+        m.execInstance = exec
 }
 
 // FindTool finds a tool by its name
 func (m *Manager) FindTool(toolPath string) ([]string, map[string]config.Parameter, string, error) {
-	parts := strings.Split(toolPath, "_")
-	if len(parts) < 1 {
-		return nil, nil, "", fmt.Errorf("invalid tool path: %s", toolPath)
-	}
+        parts := strings.Split(toolPath, "_")
+        if len(parts) < 1 {
+                return nil, nil, "", fmt.Errorf("invalid tool path: %s", toolPath)
+        }
 
-	// Find the root tool
-	var rootTool *config.Tool
-	for i := range m.config.Tools {
-		if m.config.Tools[i].Name == parts[0] {
-			rootTool = &m.config.Tools[i]
-			break
-		}
-	}
+        // Find the root tool
+        var rootTool *config.Tool
+        for i := range m.config.Tools {
+                if m.config.Tools[i].Name == parts[0] {
+                        rootTool = &m.config.Tools[i]
+                        break
+                }
+        }
 
-	if rootTool == nil {
-		return nil, nil, "", fmt.Errorf("tool not found: %s", parts[0])
-	}
+        if rootTool == nil {
+                return nil, nil, "", fmt.Errorf("tool not found: %s", parts[0])
+        }
 
-	// Start with the root tool's command
-	command := make([]string, len(rootTool.Command))
-	copy(command, rootTool.Command)
+        // Start with the root tool's command
+        command := make([]string, len(rootTool.Command))
+        copy(command, rootTool.Command)
 
-	// Collect all parameters
-	params := make(map[string]config.Parameter)
-	for name, param := range rootTool.Params {
-		params[name] = param
-	}
+        // Collect all parameters
+        params := make(map[string]config.Parameter)
+        for name, param := range rootTool.Params {
+                params[name] = param
+        }
 
-	// If we only have the root tool, return it
-	if len(parts) == 1 {
-		return command, params, "", nil
-	}
+        // If we only have the root tool, return it
+        if len(parts) == 1 {
+                return command, params, "", nil
+        }
 
-	// Navigate through subtools
-	var currentSubtool *config.Subtool
-	dangerLevel := ""
+        // Navigate through subtools
+        var currentSubtool *config.Subtool
+        dangerLevel := ""
 
-	// Join the remaining parts to form the subtool path
-	subtoolPath := strings.Join(parts[1:], "_")
+        // Join the remaining parts to form the subtool path
+        subtoolPath := strings.Join(parts[1:], "_")
 
-	// Find the matching subtool
-	found := false
-	for j := range rootTool.Subtools {
-		subtoolName := strings.ReplaceAll(rootTool.Subtools[j].Name, " ", "_")
-		if subtoolName == subtoolPath {
-			currentSubtool = &rootTool.Subtools[j]
-			found = true
-			break
-		}
-	}
+        // Find the matching subtool
+        found := false
+        for j := range rootTool.Subtools {
+                subtoolName := strings.ReplaceAll(rootTool.Subtools[j].Name, " ", "_")
+                if subtoolName == subtoolPath {
+                        currentSubtool = &rootTool.Subtools[j]
+                        found = true
+                        break
+                }
+        }
 
-	if !found {
-		return nil, nil, "", fmt.Errorf("subtool not found: %s", toolPath)
-	}
+        if !found {
+                return nil, nil, "", fmt.Errorf("subtool not found: %s", toolPath)
+        }
 
-	// Add subtool parameters
-	for name, param := range currentSubtool.Params {
-		params[name] = param
-	}
+        // Add subtool parameters
+        for name, param := range currentSubtool.Params {
+                params[name] = param
+        }
 
-	// Update danger level if specified
-	if currentSubtool.DangerLevel != "" {
-		dangerLevel = currentSubtool.DangerLevel
-	}
+        // Update danger level if specified
+        if currentSubtool.DangerLevel != "" {
+                dangerLevel = currentSubtool.DangerLevel
+        }
 
-	// Add the args from the final subtool
-	if currentSubtool != nil {
-		command = append(command, currentSubtool.Args...)
-	}
+        // Add the args from the final subtool
+        if currentSubtool != nil {
+                command = append(command, currentSubtool.Args...)
+        }
 
-	return command, params, dangerLevel, nil
+        return command, params, dangerLevel, nil
 }
 
 // ExecuteTool executes a tool with the given parameters
 func (m *Manager) ExecuteTool(toolPath string, paramValues map[string]string) error {
-	// Find the tool
-	command, params, dangerLevel, err := m.FindTool(toolPath)
-	if err != nil {
-		return err
-	}
+        // Find the tool
+        command, params, dangerLevel, err := m.FindTool(toolPath)
+        if err != nil {
+                return err
+        }
 
-	// Validate required parameters
-	for name, param := range params {
-		if param.Required {
-			value, exists := paramValues[name]
-			if !exists || value == "" {
-				return fmt.Errorf("required parameter missing: %s", name)
-			}
-		}
-	}
+        // Validate required parameters
+        for name, param := range params {
+                if param.Required {
+                        value, exists := paramValues[name]
+                        if !exists || value == "" {
+                                return fmt.Errorf("required parameter missing: %s", name)
+                        }
+                }
+        }
 
-	// Check danger level for parameters with validation rules
-	for name, param := range params {
-		value, exists := paramValues[name]
-		if exists && len(param.Validate) > 0 {
-			for _, validation := range param.Validate {
-				proceed, err := m.dangerManager.CheckDangerLevel(
-					validation.DangerLevel,
-					name,
-					value,
-					param.Validate,
-				)
-				if err != nil {
-					return err
-				}
-				if !proceed {
-					return fmt.Errorf("operation aborted due to danger level check")
-				}
-			}
-		}
-	}
+        // Check danger level for parameters with validation rules
+        for name, param := range params {
+                value, exists := paramValues[name]
+                if exists && len(param.Validate) > 0 {
+                        for _, validation := range param.Validate {
+                                proceed, err := m.dangerManager.CheckDangerLevel(
+                                        validation.DangerLevel,
+                                        name,
+                                        value,
+                                        param.Validate,
+                                )
+                                if err != nil {
+                                        return err
+                                }
+                                if !proceed {
+                                        return fmt.Errorf("operation aborted due to danger level check")
+                                }
+                        }
+                }
+        }
 
-	// Check danger level for the tool itself
-	if dangerLevel != "" {
-		proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
-		if err != nil {
-			return err
-		}
-		if !proceed {
-			return fmt.Errorf("operation aborted due to danger level check")
-		}
-	}
+        // Check danger level for the tool itself
+        if dangerLevel != "" {
+                proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
+                if err != nil {
+                        return err
+                }
+                if !proceed {
+                        return fmt.Errorf("operation aborted due to danger level check")
+                }
+        }
 
-	// Replace template parameters in command args
-	finalCommand := make([]string, len(command))
-	for i, arg := range command {
-		if strings.Contains(arg, "{{") {
-			tmpl, err := template.New("arg").Parse(arg)
-			if err != nil {
-				return fmt.Errorf("error parsing template in argument: %w", err)
-			}
+        // Replace template parameters in command args
+        finalCommand := make([]string, len(command))
+        for i, arg := range command {
+                if strings.Contains(arg, "{{") {
+                        tmpl, err := template.New("arg").Parse(arg)
+                        if err != nil {
+                                return fmt.Errorf("error parsing template in argument: %w", err)
+                        }
 
-			var buf bytes.Buffer
-			if err := tmpl.Execute(&buf, paramValues); err != nil {
-				return fmt.Errorf("error executing template in argument: %w", err)
-			}
+                        var buf bytes.Buffer
+                        if err := tmpl.Execute(&buf, paramValues); err != nil {
+                                return fmt.Errorf("error executing template in argument: %w", err)
+                        }
 
-			finalCommand[i] = buf.String()
-		} else {
-			finalCommand[i] = arg
-		}
-	}
+                        finalCommand[i] = buf.String()
+                } else {
+                        finalCommand[i] = arg
+                }
+        }
 
-	// Execute the command
-	fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
-	cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
+        // Execute the command
+        fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
+        cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
+        cmd.Stdout = os.Stdout
+        cmd.Stderr = os.Stderr
+        cmd.Stdin = os.Stdin
 
-	return cmd.Run()
+        return cmd.Run()
 }
 
 // ExecuteRawTool executes a tool with the given raw arguments
 func (m *Manager) ExecuteRawTool(toolPath string, args []string) error {
-	// Find the tool and subtool
-	command, params, dangerLevel, err := m.FindTool(toolPath)
-	if err != nil {
-		return err
-	}
+        // Find the tool and subtool
+        command, params, dangerLevel, err := m.FindTool(toolPath)
+        if err != nil {
+                return err
+        }
 
-	// Extract parameter values from the command-line arguments
-	paramValues := make(map[string]string)
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if strings.HasPrefix(arg, "-") {
-			paramName := strings.TrimLeft(arg, "-")
-			// Handle --param=value format
-			if strings.Contains(paramName, "=") {
-				parts := strings.SplitN(paramName, "=", 2)
-				paramName = parts[0]
-				paramValues[paramName] = parts[1]
-				continue
-			}
+        // Extract parameter values from the command-line arguments
+        paramValues := make(map[string]string)
+        for i := 0; i < len(args); i++ {
+                arg := args[i]
+                if strings.HasPrefix(arg, "-") {
+                        paramName := strings.TrimLeft(arg, "-")
+                        // Handle --param=value format
+                        if strings.Contains(paramName, "=") {
+                                parts := strings.SplitN(paramName, "=", 2)
+                                paramName = parts[0]
+                                paramValues[paramName] = parts[1]
+                                continue
+                        }
 
-			// Handle -p value format
-			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				paramValues[paramName] = args[i+1]
-				i++ // Skip the next arg since it's the value
-			} else {
-				// Handle boolean flags like -f
-				paramValues[paramName] = "true"
-			}
-		}
-	}
+                        // Handle -p value format
+                        if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+                                paramValues[paramName] = args[i+1]
+                                i++ // Skip the next arg since it's the value
+                        } else {
+                                // Handle boolean flags like -f
+                                paramValues[paramName] = "true"
+                        }
+                }
+        }
 
-	// Check danger level for the subtool
-	if dangerLevel != "" {
-		proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
-		if err != nil {
-			return err
-		}
-		if !proceed {
-			return fmt.Errorf("operation aborted due to danger level check")
-		}
-	}
+        // Check danger level for the subtool
+        if dangerLevel != "" {
+                proceed, err := m.dangerManager.CheckDangerLevel(dangerLevel, "", "", nil)
+                if err != nil {
+                        return err
+                }
+                if !proceed {
+                        return fmt.Errorf("operation aborted due to danger level check")
+                }
+        }
 
-	// Validate required parameters
-	for name, param := range params {
-		if param.Required {
-			value, exists := paramValues[name]
-			if !exists || value == "" {
-				return fmt.Errorf("required parameter missing: %s", name)
-			}
-		}
-	}
+        // Validate required parameters
+        for name, param := range params {
+                if param.Required {
+                        value, exists := paramValues[name]
+                        if !exists || value == "" {
+                                return fmt.Errorf("required parameter missing: %s", name)
+                        }
+                }
+        }
 
-	// Replace template parameters in command args
-	finalCommand := make([]string, len(command))
-	for i, arg := range command {
-		if strings.Contains(arg, "{{") {
-			tmpl, err := template.New("arg").Parse(arg)
-			if err != nil {
-				return fmt.Errorf("error parsing template in argument: %w", err)
-			}
+        // Replace template parameters in command args
+        finalCommand := make([]string, len(command))
+        for i, arg := range command {
+                if strings.Contains(arg, "{{") {
+                        tmpl, err := template.New("arg").Parse(arg)
+                        if err != nil {
+                                return fmt.Errorf("error parsing template in argument: %w", err)
+                        }
 
-			var buf bytes.Buffer
-			if err := tmpl.Execute(&buf, paramValues); err != nil {
-				return fmt.Errorf("error executing template in argument: %w", err)
-			}
+                        var buf bytes.Buffer
+                        if err := tmpl.Execute(&buf, paramValues); err != nil {
+                                return fmt.Errorf("error executing template in argument: %w", err)
+                        }
 
-			finalCommand[i] = buf.String()
-		} else {
-			finalCommand[i] = arg
-		}
-	}
+                        finalCommand[i] = buf.String()
+                } else {
+                        finalCommand[i] = arg
+                }
+        }
 
-	// Execute the command
-	fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
-	cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
+        // Execute the command
+        fmt.Printf("Executing: %s\n", strings.Join(finalCommand, " "))
+        cmd := exec.Command(finalCommand[0], finalCommand[1:]...)
+        cmd.Stdout = os.Stdout
+        cmd.Stderr = os.Stderr
+        cmd.Stdin = os.Stdin
 
-	return cmd.Run()
+        return cmd.Run()
 }
 
 // ListTools returns all tools and subtools defined in the config
-func (m *Manager) ListTools() []ToolInfo {
-	if m.config == nil || len(m.config.Tools) == 0 {
-		return []ToolInfo{}
-	}
+func (m *Manager) ListTools() []Info {
+        if m.config == nil || len(m.config.Tools) == 0 {
+                return []Info{}
+        }
 
-	result := make([]ToolInfo, 0, len(m.config.Tools))
+        result := make([]Info, 0, len(m.config.Tools))
 
-	for _, tool := range m.config.Tools {
-		toolInfo := ToolInfo{
-			Name:        tool.Name,
-			Description: "", // Config doesn't have description field for tools
-			Params:      tool.Params,
-			Subtools:    make([]ToolInfo, 0, len(tool.Subtools)),
-		}
+        for _, tool := range m.config.Tools {
+                toolInfo := Info{
+                        Name:        tool.Name,
+                        Description: "", // Config doesn't have description field for tools
+                        Params:      tool.Params,
+                        Subtools:    make([]Info, 0, len(tool.Subtools)),
+                }
 
-		// Add subtools recursively
-		for _, subtool := range tool.Subtools {
-			toolInfo.Subtools = append(toolInfo.Subtools, convertSubtoolToToolInfo(subtool, tool.Name))
-		}
+                // Add subtools recursively
+                for _, subtool := range tool.Subtools {
+                        toolInfo.Subtools = append(toolInfo.Subtools, convertSubtoolToInfo(subtool, tool.Name))
+                }
 
-		result = append(result, toolInfo)
-	}
+                result = append(result, toolInfo)
+        }
 
-	return result
+        return result
 }
 
-// convertSubtoolToToolInfo converts a subtool configuration to ToolInfo structure
-func convertSubtoolToToolInfo(subtool config.Subtool, parentName string) ToolInfo {
-	name := strings.ReplaceAll(subtool.Name, " ", "_")
+// convertSubtoolToInfo converts a subtool configuration to Info structure
+func convertSubtoolToInfo(subtool config.Subtool, parentName string) Info {
+        name := strings.ReplaceAll(subtool.Name, " ", "_")
 
-	toolInfo := ToolInfo{
-		Name:        name,
-		Description: "", // Config doesn't have description field for subtools
-		Params:      subtool.Params,
-		Subtools:    make([]ToolInfo, 0, len(subtool.Subtools)),
-	}
+        toolInfo := Info{
+                Name:        name,
+                Description: "", // Config doesn't have description field for subtools
+                Params:      subtool.Params,
+                Subtools:    make([]Info, 0, len(subtool.Subtools)),
+        }
 
-	// Add nested subtools recursively
-	for _, nested := range subtool.Subtools {
-		toolInfo.Subtools = append(toolInfo.Subtools,
-			convertSubtoolToToolInfo(nested, parentName+"_"+name))
-	}
+        // Add nested subtools recursively
+        for _, nested := range subtool.Subtools {
+                toolInfo.Subtools = append(toolInfo.Subtools,
+                        convertSubtoolToInfo(nested, parentName+"_"+name))
+        }
 
-	return toolInfo
+        return toolInfo
 }


### PR DESCRIPTION
This PR fixes golint issues by renaming ToolInfo to Info to avoid stuttering in the package name. Also renamed convertSubtoolToToolInfo to convertSubtoolToInfo for consistency.