### PR TITLE
Release for v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.6.1](https://github.com/takutakahashi/operation-mcp/compare/v0.6.0...v0.6.1) - 2025-04-17
+- Fix exec flag by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/32
+- Fix: Change list output format to tool_subtool format (#33) by @kommon-ai in https://github.com/takutakahashi/operation-mcp/pull/35
+
 ## [v0.5.2](https://github.com/takutakahashi/operation-mcp/compare/v0.5.1...v0.5.2) - 2025-04-17
 
 ## [v0.5.1](https://github.com/takutakahashi/operation-mcp/compare/v0.5.0...v0.5.1) - 2025-04-17


### PR DESCRIPTION
This pull request is for the next release as v0.6.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.6.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix exec flag by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/32
* Fix: Change list output format to tool_subtool format (#33) by @kommon-ai in https://github.com/takutakahashi/operation-mcp/pull/35


**Full Changelog**: https://github.com/takutakahashi/operation-mcp/compare/v0.6.0...v0.6.1