### PR TITLE
Release for v0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.6.8](https://github.com/takutakahashi/operation-mcp/compare/v0.6.7...v0.6.8) - 2025-04-20
+- issue #57: パラメータ定義をrootツールに移動し、サブツールは参照するよう変更 by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/58
+- Add e2e test for param_refs feature by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/60
+- Fix E2E test by adding required seconds parameter to sleep_short command by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/61
+
 ## [v0.6.7](https://github.com/takutakahashi/operation-mcp/compare/v0.6.6...v0.6.7) - 2025-04-18
 - feat: Add S3 remote configuration support by @kommon-ai in https://github.com/takutakahashi/operation-mcp/pull/55
 


### PR DESCRIPTION
This pull request is for the next release as v0.6.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.6.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* issue #57: パラメータ定義をrootツールに移動し、サブツールは参照するよう変更 by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/58
* Add e2e test for param_refs feature by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/60
* Fix E2E test by adding required seconds parameter to sleep_short command by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/61

## New Contributors
* @devin-ai-integration made their first contribution in https://github.com/takutakahashi/operation-mcp/pull/58

**Full Changelog**: https://github.com/takutakahashi/operation-mcp/compare/v0.6.7...v0.6.8