### PR TITLE
Release for v0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.6.10](https://github.com/takutakahashi/operation-mcp/compare/v0.6.9...v0.6.10) - 2025-04-20
+- Init manager by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/68
+- Use mcp go by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/69
+
 ## [v0.6.9](https://github.com/takutakahashi/operation-mcp/compare/v0.6.8...v0.6.9) - 2025-04-20
 - MCP Server Design Document by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/62
 - MCP Server Implementation by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/64


### PR DESCRIPTION
This pull request is for the next release as v0.6.10 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.6.10 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.9" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Init manager by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/68
* Use mcp go by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/69


**Full Changelog**: https://github.com/takutakahashi/operation-mcp/compare/v0.6.9...v0.6.10