### PR TITLE
Release for v0.6.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.6.25](https://github.com/takutakahashi/operation-mcp/compare/v0.6.24...v0.6.25) - 2025-05-15
+- release via container by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/115
+
 ## [v0.6.23](https://github.com/takutakahashi/operation-mcp/compare/v0.6.22...v0.6.23) - 2025-05-11
 
 ## [v0.6.22](https://github.com/takutakahashi/operation-mcp/compare/v0.6.21...v0.6.22) - 2025-05-11


### PR DESCRIPTION
This pull request is for the next release as v0.6.25 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.6.25 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.24" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* release via container by @takutakahashi in https://github.com/takutakahashi/operation-mcp/pull/115


**Full Changelog**: https://github.com/takutakahashi/operation-mcp/compare/v0.6.24...v0.6.25