### PR TITLE
Release for v0.6.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.6.28](https://github.com/takutakahashi/operation-mcp/compare/v0.6.27...v0.6.28) - 2025-05-23
+- Add support for processing all subdirectories in tools path by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/122
+
 ## [v0.6.27](https://github.com/takutakahashi/operation-mcp/compare/v0.6.26...v0.6.27) - 2025-05-23
 - ツールに enabled フラグを実装 by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/118
 - Fix: Update danger_level values in e2e test expected output by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/120


### PR DESCRIPTION
This pull request is for the next release as v0.6.28 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.6.28 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.27" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Add support for processing all subdirectories in tools path by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/122


**Full Changelog**: https://github.com/takutakahashi/operation-mcp/compare/v0.6.27...v0.6.28