### PR TITLE
Release for v0.6.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.6.32](https://github.com/takutakahashi/operation-mcp/compare/v0.6.31...v0.6.32) - 2025-05-24
+- Remove GitHub API and jq dependencies from install script by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/130
+- Refactor envFromLocal to envFrom.Local structure by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/132
+
 ## [v0.6.31](https://github.com/takutakahashi/operation-mcp/compare/v0.6.30...v0.6.31) - 2025-05-24
 - Add envFromLocal feature to expose specific environment variables to scripts by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/128
 


### PR DESCRIPTION
This pull request is for the next release as v0.6.32 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.6.32 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.31" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Remove GitHub API and jq dependencies from install script by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/130
* Refactor envFromLocal to envFrom.Local structure by @devin-ai-integration in https://github.com/takutakahashi/operation-mcp/pull/132


**Full Changelog**: https://github.com/takutakahashi/operation-mcp/compare/v0.6.31...v0.6.32