### PR TITLE
refactor: Unify Tool and Subtool structures

### DIFF
--- a/pkg/config/config_builder.go
+++ b/pkg/config/config_builder.go
@@ -346,8 +346,8 @@ func buildTool(dir string, processedDirs map[string]bool) (*Tool, error) {
 	return tool, nil
 }
 
-// buildSubtool はサブツールディレクトリからSubtool構造体を構築します。
-func buildSubtool(dir string, processedDirs map[string]bool) (*Subtool, error) {
+// buildSubtool はサブツールディレクトリからTool構造体を構築します。
+func buildSubtool(dir string, processedDirs map[string]bool) (*Tool, error) {
 	fmt.Printf("\n[DEBUG] buildSubtool: %s\n", dir)
 	meta, err := readMetadata(filepath.Join(dir, "metadata.yaml"))
 	if err != nil {
@@ -366,7 +366,7 @@ func buildSubtool(dir string, processedDirs map[string]bool) (*Subtool, error) {
 	processedDirs[absDir] = true
 	fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
 	
-	sub := &Subtool{}
+	sub := &Tool{}
 	sub.Name = filepath.Base(dir)
 	if description, ok := meta["description"].(string); ok {
 		sub.Description = description
@@ -602,7 +602,7 @@ func exportTool(tool *Tool, dir string) error {
 	return writeMetadata(filepath.Join(dir, "metadata.yaml"), meta)
 }
 
-func exportSubtool(sub *Subtool, dir string) error {
+func exportSubtool(sub *Tool, dir string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -140,7 +140,7 @@ func TestConfigValidate(t *testing.T) {
 						Required:    true,
 					},
 				},
-				Subtools: []Subtool{
+				Subtools: []Tool{
 					{
 						Name: "get pod",
 						Args: []string{"get", "pod", "-o", "json", "-n", "{{.namespace}}"},
@@ -166,7 +166,7 @@ func TestConfigValidate(t *testing.T) {
 						Required:    false,
 					},
 				},
-				Subtools: []Subtool{
+				Subtools: []Tool{
 					{
 						Name: "subtool1",
 						Args: []string{"arg1", "arg2"},


### PR DESCRIPTION
## Summary
- Merged Subtool type into Tool type for better code consistency
- Added Args field to Tool to support subtool functionality  
- Updated validation logic to handle both root tools and subtools

## Test plan
- [x] Updated all type references across codebase
- [x] Modified compilation logic to support unified structure
- [x] Updated CLI command generation and MCP server integration
- [x] Updated all test cases to use unified structure

🤖 Generated with [Claude Code](https://claude.ai/code)