### PR TITLE
fix: Remove debug output and update expected test output

### DIFF
--- a/misc/generate/output.yaml
+++ b/misc/generate/output.yaml
@@ -102,7 +102,6 @@ tools:
                 type: string
                 required: false
                 validate: []
-          danger_level: ""
           subtools: []
         - name: with-params
           script: |
@@ -122,5 +121,4 @@ tools:
                 type: string
                 required: true
                 validate: []
-          danger_level: ""
           subtools: []

--- a/pkg/config/config_builder.go
+++ b/pkg/config/config_builder.go
@@ -40,7 +40,7 @@ func (b *ConfigBuilder) Build(w io.Writer) error {
 
 // Compile はディレクトリ構造からConfigを構築します。
 func (b *ConfigBuilder) Compile() (*Config, error) {
-	fmt.Printf("\n[DEBUG] Starting Compile method for root dir: %s\n", b.RootDir)
+	// // fmt.Printf("\n[DEBUG] Starting Compile method for root dir: %s\n", b.RootDir)
 	// ルートのmetadata.yamlを読む
 	rootMeta, err := readMetadata(filepath.Join(b.RootDir, "metadata.yaml"))
 	if err != nil {
@@ -74,7 +74,7 @@ func (b *ConfigBuilder) Compile() (*Config, error) {
 			if path, ok := t["path"].(string); ok {
 				if path == "." {
 					
-					fmt.Printf("\n[DEBUG] Found path: . in directory: %s\n", b.RootDir)
+					// // fmt.Printf("\n[DEBUG] Found path: . in directory: %s\n", b.RootDir)
 					entries, err := os.ReadDir(b.RootDir)
 					if err != nil {
 						return nil, fmt.Errorf("failed to read directory %s: %w", b.RootDir, err)
@@ -92,7 +92,7 @@ func (b *ConfigBuilder) Compile() (*Config, error) {
 						}
 						
 						if processedDirs[subDirAbs] {
-							fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", subDirAbs)
+							// // fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", subDirAbs)
 							continue
 						}
 						
@@ -116,7 +116,7 @@ func (b *ConfigBuilder) Compile() (*Config, error) {
 				}
 				
 				if processedDirs[fullPathAbs] {
-					fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", fullPathAbs)
+					// // fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", fullPathAbs)
 					continue
 				}
 				
@@ -177,20 +177,20 @@ func readMetadata(path string) (map[string]interface{}, error) {
 }
 
 func findToolDirectories(dir string, processedDirs map[string]bool) ([]string, error) {
-	fmt.Printf("\n[DEBUG] findToolDirectories: %s\n", dir)
+	// // fmt.Printf("\n[DEBUG] findToolDirectories: %s\n", dir)
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path of directory %s: %w", dir, err)
 	}
 	
 	if processedDirs[absDir] {
-		fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", absDir)
-		fmt.Printf("\n[DEBUG] Already processed directory: %s\n", absDir)
+		// // fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", absDir)
+		// // fmt.Printf("\n[DEBUG] Already processed directory: %s\n", absDir)
 		return []string{}, nil
 	}
 	
 	processedDirs[absDir] = true
-	fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
+	// // fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
 	
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -211,7 +211,7 @@ func findToolDirectories(dir string, processedDirs map[string]bool) ([]string, e
 		}
 		
 		if processedDirs[subDirAbs] {
-						fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", subDirAbs)
+						// // fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", subDirAbs)
 			continue
 		}
 		
@@ -228,7 +228,7 @@ func findToolDirectories(dir string, processedDirs map[string]bool) ([]string, e
 
 // buildTool はツールディレクトリからTool構造体を構築します。
 func buildTool(dir string, processedDirs map[string]bool) (*Tool, error) {
-	fmt.Printf("\n[DEBUG] buildTool: %s\n", dir)
+	// // fmt.Printf("\n[DEBUG] buildTool: %s\n", dir)
 	meta, err := readMetadata(filepath.Join(dir, "metadata.yaml"))
 	if err != nil {
 		return nil, err
@@ -244,7 +244,7 @@ func buildTool(dir string, processedDirs map[string]bool) (*Tool, error) {
 	}
 	
 	processedDirs[absDir] = true
-	fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
+	// // fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
 	
 	tool := &Tool{}
 	tool.Name = filepath.Base(dir)
@@ -310,7 +310,7 @@ func buildTool(dir string, processedDirs map[string]bool) (*Tool, error) {
 		for _, s := range subDefs {
 			if path, ok := s["path"].(string); ok {
 				if path == "." {
-					fmt.Printf("\n[DEBUG] Found path: . in directory: %s\n", dir)
+					// // fmt.Printf("\n[DEBUG] Found path: . in directory: %s\n", dir)
 					continue
 				}
 				
@@ -321,7 +321,7 @@ func buildTool(dir string, processedDirs map[string]bool) (*Tool, error) {
 				}
 				
 				if processedDirs[absSubDir] {
-					fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", absSubDir)
+					// // fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", absSubDir)
 					continue
 				}
 				
@@ -348,7 +348,7 @@ func buildTool(dir string, processedDirs map[string]bool) (*Tool, error) {
 
 // buildSubtool はサブツールディレクトリからTool構造体を構築します。
 func buildSubtool(dir string, processedDirs map[string]bool) (*Tool, error) {
-	fmt.Printf("\n[DEBUG] buildSubtool: %s\n", dir)
+	// // fmt.Printf("\n[DEBUG] buildSubtool: %s\n", dir)
 	meta, err := readMetadata(filepath.Join(dir, "metadata.yaml"))
 	if err != nil {
 		return nil, err
@@ -364,7 +364,7 @@ func buildSubtool(dir string, processedDirs map[string]bool) (*Tool, error) {
 	}
 	
 	processedDirs[absDir] = true
-	fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
+	// // fmt.Printf("\n[DEBUG] Marking directory as processed: %s\n", absDir)
 	
 	sub := &Tool{}
 	sub.Name = filepath.Base(dir)
@@ -467,7 +467,7 @@ func buildSubtool(dir string, processedDirs map[string]bool) (*Tool, error) {
 		for _, s := range subDefs {
 			if path, ok := s["path"].(string); ok {
 				if path == "." {
-					fmt.Printf("\n[DEBUG] Found path: . in directory: %s\n", dir)
+					// // fmt.Printf("\n[DEBUG] Found path: . in directory: %s\n", dir)
 					continue
 				}
 				
@@ -478,7 +478,7 @@ func buildSubtool(dir string, processedDirs map[string]bool) (*Tool, error) {
 				}
 				
 				if processedDirs[absSubDir] {
-					fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", absSubDir)
+					// // fmt.Printf("\n[DEBUG] Directory already processed, skipping: %s\n", absSubDir)
 					continue
 				}
 				


### PR DESCRIPTION
## Summary
- Remove debug printf statements from config_builder.go that were causing CI failures
- Update expected output.yaml to match new YAML generation format
- Fix compile/decompile e2e test failure

## Background
After the Tool/Subtool unification, the YAML output format changed:
- `danger_level: ""` is no longer output for empty values due to `omitempty` tag
- Debug print statements were causing test output mismatches

## Test plan
- [x] Local compile/decompile e2e test passes
- [x] All other e2e tests continue to pass
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)