### PR TITLE
feat: Dockerfile に curl を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ WORKDIR /app
 # supergateway をグローバルインストール
 RUN npm install -g supergateway
 
+# curl をインストール
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 # ビルドステージからバイナリをコピー
 COPY --from=builder /app/operations /usr/local/bin/operations
 


### PR DESCRIPTION
## Summary

- `node:20-slim` ベースイメージに `curl` をインストール
- `apt-get` のキャッシュを削除してイメージサイズを最小限に抑える

## Test plan

- [ ] Docker ビルドが成功することを確認
- [ ] コンテナ内で `curl --version` が実行できることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)