### PR TITLE
Release for v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.7.3](https://github.com/takutakahashi/operations-cli/compare/v0.7.2...v0.7.3) - 2026-03-01
+- feat: Dockerfile に curl を追加 by @takutakahashi in https://github.com/takutakahashi/operations-cli/pull/145
+
 ## [v0.7.2](https://github.com/takutakahashi/operations-cli/compare/v0.7.1...v0.7.2) - 2026-03-01
 - fix: supergateway の outputTransport を streamableHttp に修正 by @takutakahashi in https://github.com/takutakahashi/operations-cli/pull/143
 


### PR DESCRIPTION
This pull request is for the next release as v0.7.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.7.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.7.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: Dockerfile に curl を追加 by @takutakahashi in https://github.com/takutakahashi/operations-cli/pull/145


**Full Changelog**: https://github.com/takutakahashi/operations-cli/compare/v0.7.2...tagpr-from-v0.7.2